### PR TITLE
Updates to avoid pointer issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # ignore secrets
 credentials.json
 token.json
+
+# ignore binaries
 codefordenver-scout
 main

--- a/pkg/discord/main.go
+++ b/pkg/discord/main.go
@@ -292,8 +292,9 @@ func Create() (*discordgo.Session, error) {
 
 	brigades = make(map[string]*global.Brigade, 0)
 
-	for _, brigade := range global.Brigades {
-		brigades[brigade.GuildID] = &brigade
+	for i := range global.Brigades {
+		brigade := &global.Brigades[i]
+		brigades[brigade.GuildID] = brigade
 	}
 
 	return dg, nil

--- a/pkg/gdrive/main.go
+++ b/pkg/gdrive/main.go
@@ -78,11 +78,12 @@ func Create() error {
 		return err
 	}
 
-	calendars := make(map[*global.Brigade]*cal.Calendar, 0)
+	calendars = make(map[*global.Brigade]*cal.Calendar, 0)
 
-	for _, brigade := range global.Brigades {
-		calendars[&brigade] = cal.NewCalendar()
-		cal.AddUsHolidays(calendars[&brigade])
+	for i := range global.Brigades {
+		brigade := &global.Brigades[i]
+		calendars[brigade] = cal.NewCalendar()
+		cal.AddUsHolidays(calendars[brigade])
 	}
 
 	return nil
@@ -170,6 +171,7 @@ func saveToken(path string, token *oauth2.Token) error {
 }
 
 func FetchAgenda(brigade *global.Brigade) (string, []string) {
+
 	location, err := time.LoadLocation(brigade.LocationString)
 	if err != nil {
 		fmt.Println(err)

--- a/pkg/github/main.go
+++ b/pkg/github/main.go
@@ -74,8 +74,9 @@ func Create(dg *discordgo.Session) error {
 
 	brigades = make(map[string]*global.Brigade, 0)
 
-	for _, brigade := range global.Brigades {
-		brigades[brigade.GithubOrg] = &brigade
+	for i := range global.Brigades {
+		brigade := &global.Brigades[i]
+		brigades[brigade.GithubOrg] = brigade
 	}
 
 	return nil


### PR DESCRIPTION
Using 
```
for _, brigade := range global.Brigades {
calendars[&brigade] = cal.NewCalendar()
}
```
takes a pointer of the copy of the brigade struct, so later using a reference to that brigade would not match the key. 